### PR TITLE
'#' no longer supported as comment in php.ini by php 7 - issue 185

### DIFF
--- a/drupal-nginx-fpm/0.44/php.ini
+++ b/drupal-nginx-fpm/0.44/php.ini
@@ -1,7 +1,7 @@
 ; http://php.net/manual/en/errorfunc.configuration.php
 log_errors=On
 error_log=/var/log/httpd/php-error.log
-#echo 'error_log=/var/log/apache2/php-error.log'; \
+; echo 'error_log=/var/log/apache2/php-error.log'; \
 display_errors=Off
 display_startup_errors=Off
 date.timezone=UTC


### PR DESCRIPTION
### Changelog
php.ini comment beginning with ';' changed to '#' as support for this was dropped in php 7, and so php was no longer accepting configuration from the file. See https://github.com/Azure/app-service-quickstart-docker-images/issues/185

## Please agree to guidelines below
Review and check the following guidelines before submitting a PR.
1. Include a README.md within version folder to describe :
	a. Any changes with deployment of use of the image 
	b. Include comments if the image is not backward compatible and how user can manually upgrade to new version 
2. SSH support included in the docker image.
3. Do no use VOLUME with the docker image since it is not supported 
4. Use only ONE external port in addition to SSH port 2222
5. Do not use chown (recursive) statements with the docker image 

Please check both statements below to agree our contribution policies. 
[x] - I have submitted the PR if you've read through the Contribution Guide and best practices checklist.
[x] - I certify that the Docker image was tested successfully at runtime using Web App for Containers or Linux Web App.

^ no changes to the above have been made.

## Pull Request Type
What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
- [ ] New Docker image version 
- [ ] BugFix in existing docker image 
- [ ] Code style formatting 
- [ ] Documetation/Readme updates 
- [x] Other . Please describe : fix in "php.ini" file