### PR TITLE
keep php error log under /home

### DIFF
--- a/drupal-nginx-fpm/0.46/Dockerfile
+++ b/drupal-nginx-fpm/0.46/Dockerfile
@@ -18,6 +18,8 @@ ENV PHPMYADMIN_HOME "/home/phpmyadmin"
 ENV DRUPAL_SOURCE "/usr/src/drupal"
 #nginx
 ENV NGINX_LOG_DIR "/home/LogFiles/nginx"
+#varnish
+ENV VARNISH_LOG_DIR "/home/LogFiles/varnish"
 #php
 ENV PHP_HOME "/usr/local/etc/php"
 ENV PHP_CONF_DIR $PHP_HOME
@@ -35,6 +37,8 @@ WORKDIR $DOCKER_BUILD_HOME
 RUN set -ex \
     && apk update \
     && apk add --no-cache varnish\
+    && rm -rf /var/log/varnish \
+	&& ln -s $VARNISH_LOG_DIR /var/log/varnish \
 # -------------
 # 1. Drupal
 # -------------

--- a/drupal-nginx-fpm/0.46/entrypoint.sh
+++ b/drupal-nginx-fpm/0.46/entrypoint.sh
@@ -215,18 +215,27 @@ cd $DRUPAL_HOME
 echo "Starting SSH ..."
 rc-service sshd start
 
+test ! -d "$NGINX_LOG_DIR" && echo "INFO: Log folder for nginx/php not found. creating..." && mkdir -p "$NGINX_LOG_DIR"
+if [ ! -e "$NGINX_LOG_DIR/php-error.log" ]; then    
+    touch $NGINX_LOG_DIR/php-error.log;    
+fi
+chmod 777 $NGINX_LOG_DIR/php-error.log;
+test ! -d "/usr/local/php/tmp" && echo "INFO: Session folder for php not found. creating..." && mkdir -p "/usr/local/php/tmp"
+chmod 777 /usr/local/php/tmp
+
 echo "Starting php-fpm ..."
 php-fpm -D
 if [ "${LISTEN_TYPE}" == "socket" ]; then  
     chmod 777 /run/php/php7.0-fpm.sock
 fi
 
+test ! -d "$VARNISH_LOG_DIR" && echo "INFO: Log folder for varnish found. creating..." && mkdir -p "$VARNISH_LOG_DIR"
 echo "Starting Varnishd ..."
 /usr/sbin/varnishd -a :80 -f /etc/varnish/default.vcl
 
 echo "Starting Nginx ..."
-mkdir -p /home/LogFiles/nginx
-if test ! -e /home/LogFiles/nginx/error.log; then 
-    touch /home/LogFiles/nginx/error.log
+if test ! -e $NGINX_LOG_DIR/error.log; then 
+    touch $NGINX_LOG_DIR/error.log
 fi
+chmod 777 $NGINX_LOG_DIR/error.log;
 /usr/sbin/nginx -g "daemon off;"

--- a/drupal-nginx-fpm/0.46/entrypoint.sh
+++ b/drupal-nginx-fpm/0.46/entrypoint.sh
@@ -219,7 +219,7 @@ test ! -d "$NGINX_LOG_DIR" && echo "INFO: Log folder for nginx/php not found. cr
 if [ ! -e "$NGINX_LOG_DIR/php-error.log" ]; then    
     touch $NGINX_LOG_DIR/php-error.log;    
 fi
-chmod 777 $NGINX_LOG_DIR/php-error.log;
+chmod 666 $NGINX_LOG_DIR/php-error.log;
 test ! -d "/usr/local/php/tmp" && echo "INFO: Session folder for php not found. creating..." && mkdir -p "/usr/local/php/tmp"
 chmod 777 /usr/local/php/tmp
 
@@ -237,5 +237,5 @@ echo "Starting Nginx ..."
 if test ! -e $NGINX_LOG_DIR/error.log; then 
     touch $NGINX_LOG_DIR/error.log
 fi
-chmod 777 $NGINX_LOG_DIR/error.log;
+chmod 666 $NGINX_LOG_DIR/error.log;
 /usr/sbin/nginx -g "daemon off;"

--- a/drupal-nginx-fpm/0.46/php.ini
+++ b/drupal-nginx-fpm/0.46/php.ini
@@ -1,6 +1,6 @@
 ; http://php.net/manual/en/errorfunc.configuration.php
 log_errors=On
-error_log=/var/log/httpd/php-error.log
+error_log=/var/log/nginx/php-error.log
 display_errors=Off
 display_startup_errors=Off
 date.timezone=UTC
@@ -15,8 +15,6 @@ upload_max_filesize=20M
 max_input_time=300
 
 session.save_path=/usr/local/php/tmp
-
-extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/apcu.so
 
 ; 504 time out issue of Drupal
 ; https://www.drupal.org/node/1343108


### PR DESCRIPTION
Related issue comments: 
https://github.com/Azure/app-service-quickstart-docker-images/pull/187#issuecomment-442894766

1. change php error log to /var/log/nginx/php-error.log. /var/nginx has already been linked to /home in base image, appsvcorg/nginx-fpm:php7.2.11.
2. also link log of varnish with /home.
3. remove lines of apce in php.ini, it has been loaded by ../conf.d/docker-php-ext-apcu.ini.

Tested, Passed.