### PR TITLE
HotFix of wordpress-alpine-php:0.72, Reduce the input size of log files.

### DIFF
--- a/wordpress-alpine-php/0.72/Dockerfile
+++ b/wordpress-alpine-php/0.72/Dockerfile
@@ -40,6 +40,7 @@ COPY ssl-settings.txt $WORDPRESS_SOURCE/
 # supervisor
 COPY supervisord.conf /etc/
 # php
+COPY php.ini /usr/local/etc/php/php.ini
 COPY www.conf /usr/local/etc/php/conf.d/
 COPY zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
 # nginx

--- a/wordpress-alpine-php/0.72/Dockerfile
+++ b/wordpress-alpine-php/0.72/Dockerfile
@@ -42,8 +42,8 @@ COPY supervisord.conf /etc/
 # php
 COPY www.conf /usr/local/etc/php/conf.d/
 COPY zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
-#
 # nginx
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY phpmyadmin-locations.txt ${PHPMYADMIN_SOURCE}/phpmyadmin-locations.txt
 #

--- a/wordpress-alpine-php/0.72/entrypoint.sh
+++ b/wordpress-alpine-php/0.72/entrypoint.sh
@@ -98,13 +98,7 @@ setup_wordpress(){
 
 update_localdb_config(){    
 	DATABASE_HOST=${DATABASE_HOST:-127.0.0.1}
-	DATABASE_NAME=${DATABASE_NAME:-azurelocaldb}
-    # DATABASE_USERNAME=${DATABASE_USERNAME:-phpmyadmin}
-	# if DATABASE_USERNAME equal phpmyadmin, it means it's nothing at beginning.
-	# if [ "${DATABASE_USERNAME}" == "phpmyadmin" ]; then
-	#    DATABASE_USERNAME='wordpress'
-	# fi	
-	# DATABASE_PASSWORD=${DATABASE_PASSWORD:-MS173m_QN}
+	DATABASE_NAME=${DATABASE_NAME:-azurelocaldb}    
     export DATABASE_HOST DATABASE_NAME DATABASE_USERNAME DATABASE_PASSWORD   
 }
 
@@ -204,12 +198,6 @@ if [ ! $AZURE_DETECTED ]; then
     crond	
 fi 
 
-# export DATABASE_HOST DATABASE_NAME DATABASE_USERNAME DATABASE_PASSWORD
-# export SSH_PORT NGINX_LOG_DIR  
-# export MARIADB_DATA_DIR MARIADB_LOG_DIR
-# export PHPMYADMIN_SOURCE PHPMYADMIN_HOME
-# export WORDPRESS_SOURCE WORDPRESS_HOME
-
 test ! -d "$SUPERVISOR_LOG_DIR" && echo "INFO: $SUPERVISOR_LOG_DIR not found. creating ..." && mkdir -p "$SUPERVISOR_LOG_DIR"
 test ! -d "$NGINX_LOG_DIR" && echo "INFO: Log folder for nginx/php not found. creating..." && mkdir -p "$NGINX_LOG_DIR"
 test ! -e /home/50x.html && echo "INFO: 50x file not found. createing..." && cp /usr/share/nginx/html/50x.html /home/50x.html
@@ -218,8 +206,8 @@ test ! -d "home/etc/nginx" && mkdir -p /home/etc && mv /etc/nginx /home/etc/ngin
 
 #Just In Case, use external DB before, change to Local DB this time.
 if [ "$DATABASE_TYPE" == "local" ]; then
-    PHPMYADMIN_SETTINGS_DETECTED=$(grep "location /phpmyadmin" /etc/nginx/conf.d/default.conf )
-    if [ ! $PHPMYADMIN_SETTINGS_DETECTED ]; then
+    PHPMYADMIN_SETTINGS_DETECTED=$(grep 'location /phpmyadmin' /etc/nginx/conf.d/default.conf )    
+    if [ ! "$PHPMYADMIN_SETTINGS_DETECTED" ]; then
         sed -i "/# Add locations of phpmyadmin here./r $PHPMYADMIN_SOURCE/phpmyadmin-locations.txt" /etc/nginx/conf.d/default.conf
     fi
 fi

--- a/wordpress-alpine-php/0.72/nginx.conf
+++ b/wordpress-alpine-php/0.72/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log error;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  2048;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  off;
+
+    sendfile        on;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/modules-enabled/*.conf;
+}

--- a/wordpress-alpine-php/0.72/php.ini
+++ b/wordpress-alpine-php/0.72/php.ini
@@ -1,0 +1,19 @@
+; http://php.net/manual/en/errorfunc.configuration.php
+log_errors=On
+error_log=/var/log/nginx/php-error.log
+error_reporting=E_ERROR
+#echo 'error_log=/var/log/apache2/php-error.log'; \
+display_errors=Off
+display_startup_errors=Off
+date.timezone=UTC
+; For drupal image thumbnails
+allow_url_fopen=On
+; to allow uploading larger files 
+; see http://php.net/manual/en/features.file-upload.common-pitfalls.php
+; http://php.net/manual/en/ini.core.php#ini.post-max-size
+post_max_size=60M
+upload_max_filesize=20M
+; http://php.net/manual/en/info.configuration.php#ini.max-input-time
+max_input_time=300
+
+session.save_path=/usr/local/php/tmp


### PR DESCRIPTION
Too big log files will impact performance.

For nginx: set access log as off. set level of error log form warn to error.
For php, set error_reporting as E_ERROR.