### PR TITLE
wordpress-alpine-php:0.81: improved watch-php-fpm

### DIFF
--- a/wordpress-alpine-php/0.81/Dockerfile
+++ b/wordpress-alpine-php/0.81/Dockerfile
@@ -1,0 +1,43 @@
+#
+# Dockerfile for WordPress
+#
+FROM appsvcorg/nginx-fpm:php7.3.4-redis
+LABEL MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+# ========
+# ENV vars
+# ========
+# ssh
+ENV SSH_PASSWD "root:Docker!"
+ENV SSH_PORT 2222
+#nginx
+ENV NGINX_LOG_DIR "/home/LogFiles/nginx"
+#php
+ENV PHP_HOME "/usr/local/etc/php"
+ENV PHP_CONF_DIR $PHP_HOME
+ENV PHP_CONF_FILE $PHP_CONF_DIR"/php.ini"
+# mariadb
+ENV MARIADB_DATA_DIR "/home/data/mysql"
+ENV MARIADB_LOG_DIR "/home/LogFiles/mysql"
+# phpmyadmin
+ENV PHPMYADMIN_SOURCE "/usr/src/phpmyadmin"
+ENV PHPMYADMIN_HOME "/home/phpmyadmin"
+# wordpress
+ENV WORDPRESS_SOURCE "/usr/src/wordpress"
+ENV WORDPRESS_HOME "/home/site/wwwroot"
+#
+ENV DOCKER_BUILD_HOME "/dockerbuild"
+# ====================
+# ====================
+# wordpress
+COPY wordpress_src/. $WORDPRESS_SOURCE/
+# supervisor
+COPY supervisord.conf /etc/
+# php
+COPY uploads.ini /usr/local/etc/php/conf.d/
+# nginx
+COPY nginx_conf/. /etc/nginx/conf.d/
+#
+COPY local_bin/. /usr/local/bin/
+RUN chmod -R +x /usr/local/bin
+EXPOSE $SSH_PORT 80
+ENTRYPOINT ["entrypoint.sh"]

--- a/wordpress-alpine-php/0.81/README.md
+++ b/wordpress-alpine-php/0.81/README.md
@@ -1,0 +1,177 @@
+# Wordpress-alpine-php Docker Image 
+This is a WordPress Docker image which can run on both [Azure Web App on Linux](https://docs.microsoft.com/en-us/azure/app-service-web/app-service-linux-intro) and your Docker engines's host.
+
+## Components
+This docker image currently contains the following components:
+
+1. WordPress
+2. Nginx (1.15.8)
+3. PHP (7.3.4) 
+4. MariaDB ( 10.1.38/if using Local Database )
+5. Phpmyadmin ( 4.8.4/if using Local Database )
+
+## How to configure to use Azure Database for MySQL with web app 
+1. Create a Web App for Containers
+2. Browse your site
+3. Complete WordPress install and Enter the Credentials for Azure database for MySQL 
+
+## How to configure GIT Repo and Branch
+1. Create a Web App for Containers 
+2. Add new App Settings
+
+Name | Default Value
+---- | -------------
+GIT_REPO | https://github.com/azureappserviceoss/wordpress-azure
+GIT_BRANCH | linux_appservice
+
+4. Browse your site
+
+>Note: GIT directory: /home/site/wwwroot.
+>
+>Note: When you deploy it first time, Sometimes need to check wp-config.php. RM it and re-config DB information is necessary.
+>
+>Note: Before restart web app, need to store your changes by "git push", it will be pulled again after restart.
+>
+
+## How to configure to use Local Database with web app 
+1. Create a Web App for Containers 
+2. Update App Setting ```WEBSITES_ENABLE_APP_SERVICE_STORAGE``` = true (If you like to keep you DB after restart.)
+3. Add new App Settings 
+
+Name | Default Value
+---- | -------------
+DATABASE_TYPE | local
+DATABASE_USERNAME | wordpress
+DATABASE_PASSWORD | some-string
+>Note: We create a database "azurelocaldb" when using local mysql . Hence use this name when setting up the app
+>
+>Note: Phpmyadmin site is deployed when using local mysql. Please go to 
+http://[website]/phpmyadmin, and login with DATABASE_USERNAME and DATABASE_PASSWORD.
+>
+4. Browse your site 
+5. Complete WordPress install
+
+>Note: Do not use the app setting DATABASE_TYPE=local if using Azure database for MySQL
+
+
+## How to turn on Xdebug
+1. By default Xdebug is turned off as turning it on impacts performance.
+2. Connect by SSH.
+3. Go to ```/usr/local/etc/php/conf.d```,  Update ```xdebug.ini``` as wish, don't modify the path of below line.
+```zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so```
+4. Save ```xdebug.ini```, 
+5. Restart php-fpm by below cmd: 
+```
+# find gid of php-fpm
+ps aux
+# Kill master process of php-fpm
+kill -INT <gid>
+# start php-fpm again
+php-fpm -D && chmod 777 /var/run/php/php7.0-fpm.sock
+```
+6. Xdebug is turned on.
+
+## How to update config files of nginx
+1. Go to "/etc/nginx", update config files as your wish. 
+2. Reload by below cmd: 
+```
+/usr/sbin/nginx -s reload
+```
+
+## Tips of Log rotate
+1. By default, log rotate is disabled if deploy this images to web app for containers of azure. It's enabled if you use this image by "docker run".
+2. Log rotate is managed by crond, you can start it with below cmd, it will check logs files in the /home/LogFiles/nginx every minute, and rotate them if bigger than 1M. Old files are stored in /home/LogFiles/olddir, keep 20 backup files by default setting.
+```
+crond
+```
+3. Please keep an eye on the log files, the performance will be going down if it's too big.
+4. If you don't like to start crond service to triage log rotate every minute, you also can manually triage it by below cmd as your wish, it will talk a while if these log files have already been too big.
+```
+logrotate /etc/logrotate.conf
+```
+
+## Updating WordPress version , themes , files
+
+If ```WEBSITES_ENABLE_APP_SERVICE_STORAGE``` = false  ( which is the default setting ) , we recommend you DO NOT update the WordPress core version , themes or files from WordPress admin dashboard.
+
+Choose either one option to updated your files :
+
+There is a tradeoff between file server stability and file persistence . Since we are using local storage for better stability for the web app , you will not get file persistence.  In this case , we recommend to follow these steps to update WordPress Core  or a theme or a Plugins version :
+1.	Fork the repo https://github.com/azureappserviceoss/wordpress-azure
+2.	Clone your repo locally and make sure to use ONLY linux-appservice branch
+3.	Download the latest version of WordPress , plugin or theme being used locally
+4.	Commit the latest version bits into local folder of your cloned repo
+5.	Push your changes to the your forked repo
+6.	Login to Azure portal and select your web app
+7.	Click on Application Settings -> App Settings and change GIT_REPO to use your repository from step #1. If you have changed the branch name , you can continue to use linux-apservice . If you wish to use a different branch , update GIT_BRANCH setting as well. 
+
+## Connect WordPress to Redis
+1. Log-in to WordPress admin. In the left navigation, select **Plugins**, and then select **Add New**.
+2. Search **Redis Object Cache**, Click **Install**, wait, then click **Activate**.
+3. In the left navigation, select **Plugins**, and then select **Installed Plugins**.
+4. In the plugins page, find **Redis Object Cache** and click **Settings**.
+5. Click the **Enable Object Cache** button.
+6. WordPress connects to the Redis server. The connection status appears on the same page.
+7. [More infomation about **Redis Object Cache**](https://wordpress.org/plugins/redis-cache)
+
+## Limitations
+- Some unexpected issues may happen after you scale out your site to multiple instances, if you deploy a WordPress site on Azure with this docker image and use the MariaDB built in this docker image as the database.
+- The phpMyAdmin built in this docker image is available only when you use the MariaDB built in this docker image as the database.
+- Please Include  App Setting ```WEBSITES_ENABLE_APP_SERVICE_STORAGE``` = true  when use built in MariaDB since we need files to be persisted.
+- Set permalink as "Day and Name" by default. Peformance issue may happen with customized permalink. If like to use customized permalink, need to modify nginx configuration and remove lines of set_permalink() in wp-settings.php.
+
+## Change Log
+
+- **Version 0.81**
+  1. Modify Watch thread of php-fpm to kill STAT D _worker_ only.
+
+- **Version 0.8**
+  1. Upgrade php-fpm and nginx.
+  2. Upgrade local mariadb.
+  3. Update conf of php-fpm.
+  4. Add Watch thread of php-fpm, kill STAT D child threads.
+
+- **Version 0.72**
+  1. Fix Permission denied of log files issue of supervisord.
+
+- **Version 0.71**
+  1. Upgrade php-fpm.
+  2. Upgrade phpmyadmin.
+  3. Add function log rotate. (It's disabed if deploy to web app of azure by default.)
+  4. Php-fpm and nginx are watched by supervisord. 
+
+- **Version 0.7**
+  1. Upgrade php-fpm.
+  2. Upgrade phpmyadmin.
+  3. Add function log rotate. (It's disabed if deploy to web app of azure by default.)
+  4. Php-fpm and nginx are watched by supervisord. 
+  
+- **Version 0.61**
+  1. Imporve Performance.
+
+- **Version 0.6**
+  1. Change to Nignx+fpm.
+  2. Update version of php to 7.2.8.  
+
+- **Version 0.51**
+  1. Add PHP simleXML module.
+  2. Bind php 7.1.7, avoid confuse of different php versions.  
+
+- **Version 0.5**
+  1. Add PHP redis extension.
+  2. Add common debug tools, tcpdump/tcptraceroute.
+  3. Fixed some Vulnerabilities.
+  
+- **Version 0.4**
+  1. Update version of Alpine/PHP/Apache/Mariadb.
+  2. Redis-server is running by default.
+  3. Reduce size.
+
+- **Version 0.3**
+  1. Use Git to deploy wordpress.
+  2. Update version of PHP/Apache/Mariadb/Phpmyadmin.
+  3. Add Xdebug extenstion of PHP.
+  4. Use supervisord to keep SSHD and Apache.
+
+# How to Contribute
+If you have feedback please create an issue but **do not send Pull requests** to these images since any changes to the images needs to tested before it is pushed to production. 

--- a/wordpress-alpine-php/0.81/local_bin/entrypoint.sh
+++ b/wordpress-alpine-php/0.81/local_bin/entrypoint.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+# set -e
+
+php -v
+
+AZURE_DETECTED=$WEBSITES_ENABLE_APP_SERVICE_STORAGE # if defined, assume the container is running on Azure
+
+setup_mariadb_data_dir(){
+    test ! -d "$MARIADB_DATA_DIR" && echo "INFO: $MARIADB_DATA_DIR not found. creating ..." && mkdir -p "$MARIADB_DATA_DIR"
+
+    # check if 'mysql' database exists
+    if [ ! -d "$MARIADB_DATA_DIR/mysql" ]; then
+	    echo "INFO: 'mysql' database doesn't exist under $MARIADB_DATA_DIR. So we think $MARIADB_DATA_DIR is empty."
+	    echo "Copying all data files from the original folder /var/lib/mysql to $MARIADB_DATA_DIR ..."
+	    cp -R /var/lib/mysql/. $MARIADB_DATA_DIR
+    else
+	    echo "INFO: 'mysql' database already exists under $MARIADB_DATA_DIR."
+    fi
+
+    rm -rf /var/lib/mysql
+    ln -s $MARIADB_DATA_DIR /var/lib/mysql
+    chown -R mysql:mysql $MARIADB_DATA_DIR
+    test ! -d /run/mysqld && echo "INFO: /run/mysqld not found. creating ..." && mkdir -p /run/mysqld
+    chown -R mysql:mysql /run/mysqld
+}
+
+start_mariadb(){
+    if test ! -e /run/mysqld/mysqld.sock; then
+        touch /run/mysqld/mysqld.sock
+    fi
+    chmod 777 /run/mysqld/mysqld.sock
+    mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+    /usr/bin/mysqld --user=mysql &
+    # make sure mysql service is started...
+    port=`netstat -nlt|grep 3306|wc -l`
+    process=`ps -ef |grep mysql|grep -v grep |wc -l`
+    try_count=1
+
+    while [ $try_count -le 10 ]
+    do 
+        if [ $port -eq 1 ] && [ $process -eq 1 ]; then 
+            echo "INFO: MariaDB is running... "            
+            break
+        else            
+            echo "INFO: Haven't found MariaDB Service this time, Wait 10s, try again..."
+            sleep 10s
+            let try_count+=1
+            port=`netstat -nlt|grep 3306|wc -l`
+            process=`ps -ef |grep mysql|grep -v grep |wc -l`    
+        fi
+    done    
+}
+#unzip phpmyadmin
+setup_phpmyadmin(){
+    test ! -d "$PHPMYADMIN_HOME" && echo "INFO: $PHPMYADMIN_HOME not found. creating..." && mkdir -p "$PHPMYADMIN_HOME"
+    cd $PHPMYADMIN_SOURCE
+    tar -xf phpMyAdmin.tar.gz -C $PHPMYADMIN_HOME --strip-components=1
+    cp -R phpmyadmin-config.inc.php $PHPMYADMIN_HOME/config.inc.php    
+    sed -i "/# Add locations of phpmyadmin here./r $PHPMYADMIN_SOURCE/phpmyadmin-locations.txt" /etc/nginx/conf.d/default.conf
+	cd /
+    # rm -rf $PHPMYADMIN_SOURCE
+    if [ ! $AZURE_DETECTED ]; then
+        echo "INFO: NOT in Azure, chown for "$PHPMYADMIN_HOME  
+        chown -R nginx:nginx $PHPMYADMIN_HOME
+    fi 
+}    
+
+setup_wordpress(){
+	if ! [ -e wp-includes/version.php ]; then
+        echo "INFO: There in no wordpress, going to GIT pull...:"
+        while [ -d $WORDPRESS_HOME ]
+        do
+            mkdir -p /home/bak
+            mv $WORDPRESS_HOME /home/bak/wordpress_bak$(date +%s)            
+        done
+        GIT_REPO=${GIT_REPO:-https://github.com/azureappserviceoss/wordpress-azure}
+	    GIT_BRANCH=${GIT_BRANCH:-linux-appservice}
+	    echo "INFO: ++++++++++++++++++++++++++++++++++++++++++++++++++:"
+	    echo "REPO: "$GIT_REPO
+	    echo "BRANCH: "$GIT_BRANCH
+	    echo "INFO: ++++++++++++++++++++++++++++++++++++++++++++++++++:"
+    
+	    echo "INFO: Clone from "$GIT_REPO		
+        git clone $GIT_REPO $WORDPRESS_HOME	&& cd $WORDPRESS_HOME
+	    if [ "$GIT_BRANCH" != "master" ];then
+		    echo "INFO: Checkout to "$GIT_BRANCH
+		    git fetch origin
+	        git branch --track $GIT_BRANCH origin/$GIT_BRANCH && git checkout $GIT_BRANCH
+	    fi       
+        #IF App settings of DB are exist, Use Special wp-config file.    
+        if [ "${DATABASE_TYPE}" == "local" ]; then        
+            cp $WORDPRESS_SOURCE/wp-config.php $WORDPRESS_HOME/ && chmod 777 $WORDPRESS_HOME/wp-config.php        
+        else
+            if [ $DATABASE_HOST ]; then
+                echo "INFO: External Mysql is used."                
+                # show_wordpress_db_config
+                cp $WORDPRESS_SOURCE/wp-config.php $WORDPRESS_HOME/ && chmod 777 $WORDPRESS_HOME/wp-config.php            
+            fi        
+        fi        		        
+    else
+        echo "INFO: There is one wordpress exist, no need to GIT pull again."
+    fi
+	
+	# Although in AZURE, we still need below chown cmd.
+    chown -R nginx:nginx $WORDPRESS_HOME    
+}
+
+update_localdb_config(){    
+	DATABASE_HOST=${DATABASE_HOST:-127.0.0.1}
+	DATABASE_NAME=${DATABASE_NAME:-azurelocaldb}    
+    export DATABASE_HOST DATABASE_NAME DATABASE_USERNAME DATABASE_PASSWORD    
+}
+
+echo "Setup openrc ..." && openrc && touch /run/openrc/softlevel
+
+DATABASE_TYPE=$(echo ${DATABASE_TYPE}|tr '[A-Z]' '[a-z]')
+if [ "${DATABASE_TYPE}" == "local" ]; then
+    echo "Starting MariaDB and PHPMYADMIN..."  
+    echo 'mysql.default_socket = /run/mysqld/mysqld.sock' >> $PHP_CONF_FILE     
+    echo 'mysqli.default_socket = /run/mysqld/mysqld.sock' >> $PHP_CONF_FILE     
+    #setup MariaDB
+    echo "INFO: loading local MariaDB and phpMyAdmin ..."
+    echo "Setting up MariaDB data dir ..."
+    setup_mariadb_data_dir
+    echo "Setting up MariaDB log dir ..."
+    test ! -d "$MARIADB_LOG_DIR" && echo "INFO: $MARIADB_LOG_DIR not found. creating ..." && mkdir -p "$MARIADB_LOG_DIR"
+    chown -R mysql:mysql $MARIADB_LOG_DIR
+    echo "Starting local MariaDB ..."
+    start_mariadb
+    echo "Installing phpMyAdmin ..."
+    setup_phpmyadmin
+    echo "Granting user for phpMyAdmin ..."
+    # Set default value of username/password if they are't exist/null.
+    DATABASE_USERNAME=${DATABASE_USERNAME:-phpmyadmin}
+    DATABASE_PASSWORD=${DATABASE_PASSWORD:-MS173m_QN}
+	echo "INFO: ++++++++++++++++++++++++++++++++++++++++++++++++++:"
+    echo "phpmyadmin username:" $DATABASE_USERNAME
+    echo "phpmyadmin password:" $DATABASE_PASSWORD
+    echo "INFO: ++++++++++++++++++++++++++++++++++++++++++++++++++:"
+    mysql -u root -e "GRANT ALL ON *.* TO \`$DATABASE_USERNAME\`@'localhost' IDENTIFIED BY '$DATABASE_PASSWORD' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+    echo "INFO: local MariaDB is used."
+    update_localdb_config
+    # show_wordpress_db_config
+    echo "Creating database for WordPress if not exists ..."
+    chown -R mysql:mysql $MARIADB_DATA_DIR && mysql -u root -e "CREATE DATABASE IF NOT EXISTS \`$DATABASE_NAME\` CHARACTER SET utf8 COLLATE utf8_general_ci;"
+	echo "Granting user for WordPress ..."
+	mysql -u root -e "GRANT ALL ON \`$DATABASE_NAME\`.* TO \`$DATABASE_USERNAME\`@\`$DATABASE_HOST\` IDENTIFIED BY '$DATABASE_PASSWORD'; FLUSH PRIVILEGES;"        
+fi
+
+# That wp-config.php doesn't exist means WordPress is not installed/configured yet.
+if [ ! -e "$WORDPRESS_HOME/wp-config.php" ]; then
+	echo "INFO: $WORDPRESS_HOME/wp-config.php not found."    
+	echo "Installing WordPress for the first time ..." 
+	setup_wordpress
+fi
+
+chmod 777 $WORDPRESS_SOURCE/wp-config.php
+if [ ! $AZURE_DETECTED ]; then 
+    echo "INFO: NOT in Azure, chown for wp-config.php"
+    chown -R nginx:nginx $WORDPRESS_SOURCE/wp-config.php
+fi
+
+if [  -e "$WORDPRESS_HOME/wp-config.php" ]; then
+    echo "INFO: Check SSL Setting..."    
+    SSL_DETECTED=$(grep "\$_SERVER\['HTTPS'\] = 'on';" $WORDPRESS_HOME/wp-config.php)
+    if [ ! SSL_DETECTED ];then
+        echo "INFO: Add SSL Setting..."
+        sed -i "/stop editing!/r $WORDPRESS_SOURCE/ssl-settings.txt" $WORDPRESS_HOME/wp-config.php        
+    else        
+        echo "INFO: SSL Setting is exist!"
+    fi
+fi
+
+# setup server root
+if [ ! $AZURE_DETECTED ]; then 
+    echo "INFO: NOT in Azure, chown for "$WORDPRESS_HOME 
+    chown -R nginx:nginx $WORDPRESS_HOME
+fi
+
+echo "Starting Redis ..."
+redis-server &
+
+if [ ! $AZURE_DETECTED ]; then	
+    echo "NOT in AZURE, Start crond, log rotate..."	
+    crond	
+fi 
+
+test ! -d "$SUPERVISOR_LOG_DIR" && echo "INFO: $SUPERVISOR_LOG_DIR not found. creating ..." && mkdir -p "$SUPERVISOR_LOG_DIR"
+test ! -d "$NGINX_LOG_DIR" && echo "INFO: Log folder for nginx/php not found. creating..." && mkdir -p "$NGINX_LOG_DIR"
+test ! -e /home/50x.html && echo "INFO: 50x file not found. createing..." && cp /usr/share/nginx/html/50x.html /home/50x.html
+# test -d "/home/etc/nginx" && mv /etc/nginx /etc/nginx-bak && ln -s /home/etc/nginx /etc/nginx
+# test ! -d "home/etc/nginx" && mkdir -p /home/etc && mv /etc/nginx /home/etc/nginx && ln -s /home/etc/nginx /etc/nginx
+if [ ! -d "/home/etc/nginx" ]; then
+    mkdir -p /home/etc && mv /etc/nginx /home/etc/nginx
+else
+    mv /etc/nginx /etc/nginx-bak
+    # Is it upgrade from 0.72? 
+    sed -i "s/php7.0-fpm.sock/php-fpm.sock/g" /home/etc/nginx/conf.d/default.conf
+fi
+ln -s /home/etc/nginx /etc/nginx
+
+#Just In Case, use external DB before, change to Local DB this time.
+if [ "$DATABASE_TYPE" == "local" ]; then
+    PHPMYADMIN_SETTINGS_DETECTED=$(grep 'location /phpmyadmin' /etc/nginx/conf.d/default.conf )    
+    if [ ! "$PHPMYADMIN_SETTINGS_DETECTED" ]; then
+        sed -i "/# Add locations of phpmyadmin here./r $PHPMYADMIN_SOURCE/phpmyadmin-locations.txt" /etc/nginx/conf.d/default.conf
+    fi
+fi
+
+echo "INFO: creating /run/php/php-fpm.sock ..."
+test -e /run/php/php-fpm.sock && rm -f /run/php/php-fpm.sock
+mkdir -p /run/php
+touch /run/php/php-fpm.sock
+chown nginx:nginx /run/php/php-fpm.sock
+chmod 777 /run/php/php-fpm.sock
+
+sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
+echo "Starting SSH ..."
+echo "Starting php-fpm ..."
+echo "Starting Nginx ..."
+
+cd /usr/bin/
+supervisord -c /etc/supervisord.conf
+

--- a/wordpress-alpine-php/0.81/local_bin/watch-php-fpm.sh
+++ b/wordpress-alpine-php/0.81/local_bin/watch-php-fpm.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+LOG_OUTPUT=/var/log/watch-php-fpm.log
+ROLLING_LOGS=""
+THRESHOLD=15
+
+echo [$(date)] Started $0 >> $LOG_OUTPUT
+
+while [ 1 ]
+do
+    STALE_PIDS=$(top -b -n 1 | grep " D " | grep "php-fpm: pool" | sed 's/^\s*//' | cut -d " " -f 1 | tr '\n' ',')
+    ROLLING_LOGS=$(echo -e "$ROLLING_LOGS\n$STALE_PIDS" | tail -$THRESHOLD)
+    STAT=$(echo "$ROLLING_LOGS" | tr ',' '\n' | sed '/^$/d' | sort | uniq -c | sed 's/^\s*//')
+    BAD_PIDS=$(echo "$STAT" | grep "$THRESHOLD " | cut -d ' ' -f 2)
+
+    if [ $(echo "$BAD_PIDS" | wc -l) -gt 1 ]; then
+        echo [$(date)] Killing $BAD_PIDS >> $LOG_OUTPUT
+        kill -9 $BAD_PIDS
+    fi
+
+    sleep 1s
+done

--- a/wordpress-alpine-php/0.81/nginx_conf/default.conf
+++ b/wordpress-alpine-php/0.81/nginx_conf/default.conf
@@ -1,0 +1,81 @@
+upstream php {
+        server unix:/var/run/php/php-fpm.sock;        
+        #server 127.0.0.1:9000;
+}
+
+server {
+        listen 80;
+        ## Your website name goes here.
+        server_name _;
+        ## Your only path reference.
+        root /home/site/wwwroot;
+        ## This should be in your http block and if it is, it's not needed here.
+        index index.php;
+
+        location = /favicon.ico {
+                log_not_found off;
+                access_log off;
+        }
+
+        location = /robots.txt {
+                allow all;
+                log_not_found off;
+                access_log off;
+        }
+
+  # Add locations of phpmyadmin here.
+
+  # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+  sendfile off;
+
+  set $skip_cache 0;
+
+  # POST requests and urls with a query string should always go to PHP
+  if ($request_method = POST) {
+    set $skip_cache 1;
+  }
+  if ($query_string != "") {
+    set $skip_cache 1;
+  }
+
+  # Don't cache uris containing the following segments
+  if ($request_uri ~* "/wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml") {
+    set $skip_cache 1;
+  }
+
+  # Don't use the cache for logged in users or recent commenters
+  if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+    set $skip_cache 1;
+  }
+
+  # Don't cache WooCommerce URLs
+  # Cart widgets are still a problem: https://github.com/emcniece/docker-wordpress/issues/3
+  if ($request_uri ~* "/(cart|checkout|my-account)/*$") {
+    set $skip_cache 1;
+  }
+
+        location / {
+                # This is cool because no php is touched for static content.
+                # include the "?$args" part so non-default permalinks doesn't break when using query string
+                try_files $uri $uri/ /index.php?$args;
+        }
+
+        location ~ \.php$ {
+                #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+                include fastcgi.conf;
+                include fastcgi_params;
+                fastcgi_intercept_errors on;
+                fastcgi_pass php;
+
+                fastcgi_read_timeout 300;
+                fastcgi_cache_bypass $skip_cache;
+                fastcgi_no_cache $skip_cache;
+                fastcgi_cache WORDPRESS;
+                fastcgi_cache_valid 60m;                
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+                expires max;
+                log_not_found off;
+        }
+}

--- a/wordpress-alpine-php/0.81/nginx_conf/spec-settings.conf
+++ b/wordpress-alpine-php/0.81/nginx_conf/spec-settings.conf
@@ -1,0 +1,82 @@
+##
+# Basic Settings
+##
+
+tcp_nopush on;
+tcp_nodelay on;
+types_hash_max_size 2048;
+server_tokens off;
+underscores_in_headers  on;
+
+# allow '.' chars in headers
+ignore_invalid_headers  off;
+keepalive_timeout  65;
+client_header_timeout 4m;
+client_body_timeout 4m;
+send_timeout 4m;
+reset_timedout_connection on;
+aio threads=default;
+
+client_max_body_size 512M;
+
+# 414 prevention
+client_header_buffer_size 256k;
+large_client_header_buffers 8 1024k;
+
+##
+# Timeout Settings
+##
+
+proxy_connect_timeout  240s;
+proxy_send_timeout  240s;
+proxy_read_timeout  240s;
+fastcgi_send_timeout 600s;
+fastcgi_read_timeout 600s;
+
+##
+# Proxy Forwarding
+##
+
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Server $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header Host $host;
+
+##
+# Gzip Settings
+##
+
+gzip on;
+gzip_disable "msie6";
+
+# gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 2;
+# gzip_buffers 16 8k;
+# gzip_http_version 1.1;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+
+##
+# FastCGI Cache
+##
+
+add_header Fastcgi-Cache $upstream_cache_status;
+fastcgi_cache_key "$scheme$request_method$host$request_uri";
+fastcgi_cache_use_stale error timeout invalid_header http_500;
+fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
+fastcgi_intercept_errors on;
+fastcgi_cache_path /tmp/cache levels=1:2 keys_zone=WORDPRESS:100m inactive=60m;
+
+
+
+##
+# Security
+##
+
+#add_header Content-Security-Policy "default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval';" always;
+add_header X-Xss-Protection "1; mode=block" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;

--- a/wordpress-alpine-php/0.81/supervisord.conf
+++ b/wordpress-alpine-php/0.81/supervisord.conf
@@ -1,0 +1,33 @@
+[supervisord]
+nodaemon=true
+logfile=/home/LogFiles/supervisor/supervisord.log
+logfile_maxbytes=1MB       ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10          ; (num of main logfile rotation backups;default 10)
+unmask=0000
+user=root
+;loglevel=debug             
+
+[program:sshd]
+command=rc-service sshd start
+
+[program:watch-log-files]
+command=sh /usr/local/bin/super_log_files.sh
+
+[program:watch-php-fpm]
+command=sh /usr/local/bin/watch-php-fpm.sh
+
+[program:php-fpm]
+command=php-fpm
+autostart=true
+autorestart=true
+priority=5
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:nginx]
+command=/usr/sbin/nginx -g 'daemon off;'
+autostart=true
+autorestart=true
+priority=10
+stdout_events_enabled=true
+stderr_events_enabled=true

--- a/wordpress-alpine-php/0.81/uploads.ini
+++ b/wordpress-alpine-php/0.81/uploads.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 256M
+upload_max_filesize = 256M
+post_max_size = 300M
+max_execution_time = 600

--- a/wordpress-alpine-php/0.81/wordpress_src/ssl-settings.txt
+++ b/wordpress-alpine-php/0.81/wordpress_src/ssl-settings.txt
@@ -1,0 +1,3 @@
+/**https://codex.wordpress.org/Function_Reference/is_ssl */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+	$_SERVER['HTTPS'] = 'on';

--- a/wordpress-alpine-php/0.81/wordpress_src/wp-config.php
+++ b/wordpress-alpine-php/0.81/wordpress_src/wp-config.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+//Using environment variables for DB connection information
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+
+$connectstr_dbhost = getenv('DATABASE_HOST');
+$connectstr_dbname = getenv('DATABASE_NAME');
+$connectstr_dbusername = getenv('DATABASE_USERNAME');
+$connectstr_dbpassword = getenv('DATABASE_PASSWORD');
+
+
+define('DB_NAME', $connectstr_dbname);
+
+/** MySQL database username */
+define('DB_USER', $connectstr_dbusername);
+
+/** MySQL database password */
+define('DB_PASSWORD',$connectstr_dbpassword);
+
+/** MySQL hostname */
+define('DB_HOST', $connectstr_dbhost);
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define( 'WP_DEBUG', false );
+
+/* That's all, stop editing! Happy blogging. */
+/**https://codex.wordpress.org/Function_Reference/is_ssl */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+	$_SERVER['HTTPS'] = 'on';
+
+//Relative URLs for swapping across app service deployment slots
+define('WP_HOME', 'http://'. $_SERVER['HTTP_HOST']);
+define('WP_SITEURL', 'http://'. $_SERVER['HTTP_HOST']);
+define('WP_CONTENT_URL', '/wp-content');
+define('DOMAIN_CURRENT_SITE', $_SERVER['HTTP_HOST']);
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+	
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
### Changelog
Added wordpress-alpine-php:0.81 
- Modify Watch thread of php-fpm to kill STAT D _worker_ only. (Solves #337)

## Please agree to guidelines below
Review and check the following guidelines before submitting a PR.
1. Include a README.md within version folder to describe :
	a. Any changes with deployment of use of the image 
	b. Include comments if the image is not backward compatible and how user can manually upgrade to new version 
2. SSH support included in the docker image.
3. Do no use VOLUME with the docker image since it is not supported 
4. Use only ONE external port in addition to SSH port 2222
5. Do not use chown (recursive) statements with the docker image 

Please check both statements below to agree our contribution policies. 
[x] - I have submitted the PR if you've read through the Contribution Guide and best practices checklist.
[x] - I certify that the Docker image was tested successfully at runtime using Web App for Containers or Linux Web App.


## Pull Request Type
What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
- [x] New Docker image version 
- [ ] BugFix in existing docker image 
- [ ] Code style formatting 
- [ ] Documetation/Readme updates 
- [ ] Other . Please describe : .....